### PR TITLE
Fix effects not rendering when OpenGL 3.x is used

### DIFF
--- a/gdx-vfx/core/src/com/crashinvaders/vfx/utils/ViewportQuadMesh.java
+++ b/gdx-vfx/core/src/com/crashinvaders/vfx/utils/ViewportQuadMesh.java
@@ -40,7 +40,7 @@ public class ViewportQuadMesh {
 	}
 
 	public ViewportQuadMesh(VertexAttribute... vertexAttributes) {
-		mesh = new Mesh(VertexDataType.VertexArray, true, 4, 0, vertexAttributes);
+		mesh = new Mesh(true, 4, 0, vertexAttributes);
 		mesh.setVertices(verts);
 	}
 


### PR DESCRIPTION
When OpenGL 3.x is enabled, effects (and sometimes even the whole buffer) are not displayed. 

## Steps to reproduce

1. Open `DesktopLauncher.java` [in the demo source](https://github.com/crashinvaders/gdx-vfx/blob/master/demo/desktop/src/com/crashinvaders/vfx/demo/desktop/DesktopLauncher.java).
2. Add the line: `config.useOpenGL3(true, 3, 0);` *(3, 2 will cause the same issue)*
3. Run the demo. Add some effects. Observe that when an odd amount of effects is added, nothing is rendered. When the amount is even, the buffer is shown, but the affects are not applied.

## The Cause

`ViewportQuadMesh` uses `VertexDataType.VertexArray`, which is not supported on OpenGL 3.x. Removing the explicit data type specification makes the `Mesh` choose its own data type based on the type of OpenGL available.