### PR TITLE
Fix duplicate assets

### DIFF
--- a/gdx-vfx/effects/build.gradle
+++ b/gdx-vfx/effects/build.gradle
@@ -26,4 +26,5 @@ jar {
     from('assets') {
         include '**/*'
     }
+    duplicatesStrategy(DuplicatesStrategy.EXCLUDE)
 }


### PR DESCRIPTION
Fixes #24 

## Original:
![image](https://github.com/crashinvaders/gdx-vfx/assets/30625109/2acb1769-a759-45dc-8149-4e20eb7412aa)

## After:
![image](https://github.com/crashinvaders/gdx-vfx/assets/30625109/45a397ae-0731-474f-85cc-478830ebdf32)
